### PR TITLE
Windows support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,3 +19,4 @@ keywords = [
 [lib]
 
 [dependencies]
+os_str_bytes = "1.0"

--- a/src/arg.rs
+++ b/src/arg.rs
@@ -62,8 +62,8 @@ impl ArgString for String {
 
 impl ArgString for OsString {
     fn parse_arg(self) -> Result<ParsedArg<OsString>, OsString> {
-        use std::os::unix::ffi::{OsStrExt, OsStringExt};
-        let bytes = self.as_bytes();
+        use os_str_bytes::{OsStrBytes, OsStringBytes};
+        let bytes = self.to_bytes();
         if bytes.len() < 2 || bytes[0] != b'-' {
             return Ok(ParsedArg::Positional(self));
         }
@@ -87,7 +87,7 @@ impl ArgString for OsString {
         }
         let name = Vec::from(name);
         let name = unsafe { String::from_utf8_unchecked(name) };
-        let value = value.map(|v| OsString::from_vec(Vec::from(v)));
+        let value = value.map(|v| unsafe { OsString::from_bytes_unchecked(v) });
         Ok(ParsedArg::Named(name, value))
     }
 


### PR DESCRIPTION
Hi. I was looking at different argument parsing libraries and noticed this in the README:

> No Windows support yet! OsString is a different beast on Windows. No, we can’t write generic code that works both on Windows and non-Windows systems.

I created [os\_str\_bytes](https://crates.io/crates/os_str_bytes), so I figured I'd make a quick PR. Feel free to close this if you're not interested.